### PR TITLE
chore: update color package usage to support package

### DIFF
--- a/cos.go
+++ b/cos.go
@@ -11,11 +11,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gookit/color"
 	"github.com/goravel/framework/contracts/config"
 	"github.com/goravel/framework/contracts/filesystem"
 	contractshttp "github.com/goravel/framework/contracts/http"
 	"github.com/goravel/framework/support/carbon"
+	"github.com/goravel/framework/support/color"
 	"github.com/goravel/framework/support/str"
 	"github.com/tencentyun/cos-go-sdk-v5"
 )
@@ -417,7 +417,7 @@ func (r *Cos) WithContext(ctx context.Context) filesystem.Driver {
 
 	driver, err := NewCos(ctx, r.config, r.disk)
 	if err != nil {
-		color.Redf("init %s disk fail: %v\n", r.disk, err)
+		color.Red().Printfln("init %s disk fail: %v", r.disk, err)
 
 		return nil
 	}

--- a/cos_test.go
+++ b/cos_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gookit/color"
+	"github.com/goravel/framework/support/color"
 	"github.com/stretchr/testify/assert"
 
 	filesystemcontract "github.com/goravel/framework/contracts/filesystem"
@@ -18,7 +18,7 @@ import (
 
 func TestStorage(t *testing.T) {
 	if os.Getenv("TENCENT_ACCESS_KEY_ID") == "" {
-		color.Redln("No filesystem tests run, please add cos configuration: TENCENT_ACCESS_KEY_ID= TENCENT_ACCESS_KEY_SECRET= TENCENT_URL= go test ./...")
+		color.Red().Println("No filesystem tests run, please add cos configuration: TENCENT_ACCESS_KEY_ID= TENCENT_ACCESS_KEY_SECRET= TENCENT_URL= go test ./...")
 		return
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.23.0
 toolchain go1.25.1
 
 require (
-	github.com/gookit/color v1.5.4
 	github.com/goravel/framework v1.16.3
 	github.com/stretchr/testify v1.11.1
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.69
@@ -25,6 +24,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.9 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/gookit/color v1.5.4 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect


### PR DESCRIPTION
## 📑 Description

Replaces direct usage of the external gookit/color package with the internal github.com/goravel/framework/support/color package, and updates the method calls for printing colored output. Additionally, the dependency on gookit/color is now marked as indirect in go.mod.

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
